### PR TITLE
clarify walk time is for transfers, default to 2 min

### DIFF
--- a/packages/client/src/components/TripSelector.tsx
+++ b/packages/client/src/components/TripSelector.tsx
@@ -23,7 +23,7 @@ export function TripSelector({
 }: TripSelectorProps) {
   const [fromStation, setFromStation] = useState<Station | null>(null)
   const [toStation, setToStation] = useState<Station | null>(null)
-  const [walkTime, setWalkTime] = useState(3)
+  const [walkTime, setWalkTime] = useState(2)
 
   const canGo = fromStation && toStation && fromStation.code !== toStation.code
 
@@ -68,14 +68,14 @@ export function TripSelector({
         {/* Walk time */}
         <div className="shrink-0">
           <label className="block text-sm font-medium text-[var(--text-secondary)] mb-1.5">
-            Walk
+            Transfer walk
           </label>
           <select
             value={walkTime}
             onChange={(e) => setWalkTime(Number(e.target.value))}
             className="w-full lg:w-24 px-3 py-2 bg-[var(--input-bg)] border border-[var(--border-color)] rounded text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
-            {[1, 2, 3, 4, 5, 6, 7, 8].map(min => (
+            {[1, 2, 3, 4, 5].map(min => (
               <option key={min} value={min}>{min} min</option>
             ))}
           </select>

--- a/packages/server/src/routes/trips.ts
+++ b/packages/server/src/routes/trips.ts
@@ -75,7 +75,7 @@ const booleanFromString = z.preprocess(
 const tripQuerySchema = z.object({
   from: z.string().min(2).max(4),
   to: z.string().min(2).max(4),
-  walkTime: z.coerce.number().min(1).max(15).default(3),
+  walkTime: z.coerce.number().min(1).max(5).default(2),
   transferStation: z.string().optional(), // pick a specific transfer if you fancy
   accessible: booleanFromString, // true = favor elevators
   includeDeparted: booleanFromString // true = also show trains that already bailed
@@ -84,7 +84,7 @@ const tripQuerySchema = z.object({
 const leg2QuerySchema = z.object({
   // allow negative numbers (e.g. -120) for already-departed trains
   departureMin: z.coerce.number().min(-120).max(120),
-  walkTime: z.coerce.number().min(1).max(15).default(3),
+  walkTime: z.coerce.number().min(1).max(5).default(2),
   transferStation: z.string().optional(),
   // realtime arrival at transfer station (if WMATA/GTFS-RT feels helpful)
   transferArrivalMin: z.coerce.number().optional(),

--- a/packages/server/src/services/pathfinding.ts
+++ b/packages/server/src/services/pathfinding.ts
@@ -8,7 +8,7 @@ import { calculateRouteTravelTime, getTerminus } from './travelTime.js'
 /**
  * Default transfer walk time in minutes
  */
-const DEFAULT_TRANSFER_WALK_TIME = 3
+const DEFAULT_TRANSFER_WALK_TIME = 2
 
 /**
  * Find all possible transfer stations between origin and destination


### PR DESCRIPTION
Renamed "Walk" to "Transfer walk" to make it clear this is for walking between platforms at a transfer station, not walking to the origin station. Also reduced max from 8 to 5 min and changed default from 3 to 2 min.